### PR TITLE
Don't add security token header if empty

### DIFF
--- a/src/AuthenticationPayloadCreator.js
+++ b/src/AuthenticationPayloadCreator.js
@@ -64,7 +64,10 @@ ${createHash('sha256').update(canonicalRequest, 'utf8').digest('hex')}`
     canonicalQueryString += `${encodeURIComponent('X-Amz-Credential')}=${encodeURIComponent(xAmzCredential)}&`
     canonicalQueryString += `${encodeURIComponent('X-Amz-Date')}=${encodeURIComponent(dateString)}&`
     canonicalQueryString += `${encodeURIComponent('X-Amz-Expires')}=${encodeURIComponent(this.ttl)}&`
-    canonicalQueryString += `${encodeURIComponent('X-Amz-Security-Token')}=${encodeURIComponent(sessionToken)}&`
+
+    if (sessionToken)
+      canonicalQueryString += `${encodeURIComponent('X-Amz-Security-Token')}=${encodeURIComponent(sessionToken)}&`
+
     canonicalQueryString += `${encodeURIComponent('X-Amz-SignedHeaders')}=${encodeURIComponent(SIGNED_HEADERS)}`
 
     return canonicalQueryString


### PR DESCRIPTION
Hey @jmaver-plume ! Thanks for this library, it's been super helpful for us.

Just one quick suggested amendment: We found that this library doesn't work if you've chosen to go with non-temporary auth credentials as the code assumes a session token is present. Adding this null check on `sessionToken` allows just access key ID and secret access key credentials to be used, which is our use case.