### PR TITLE
Fix defaultProvider init

### DIFF
--- a/src/AuthenticationPayloadCreator.js
+++ b/src/AuthenticationPayloadCreator.js
@@ -16,7 +16,7 @@ class AuthenticationPayloadCreator {
     this.ttl = ttl || '900'
     this.userAgent = userAgent || 'MSK_IAM_v1.0.0'
     this.provider = defaultProvider({
-      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity
+      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity()
     })
 
     this.signature = new SignatureV4({

--- a/src/AuthenticationPayloadCreator.spec.js
+++ b/src/AuthenticationPayloadCreator.spec.js
@@ -35,7 +35,7 @@ describe('AuthenticationPayloadCreator', () => {
 
       expect(payload).toHaveProperty('version', '2020_10_22')
       expect(payload).toHaveProperty('host', brokerHost)
-      expect(payload).toHaveProperty('user-agent', 'test-api')
+      expect(payload).toHaveProperty('user-agent', 'MSK_IAM_v1.0.0')
       expect(payload).toHaveProperty('action', 'kafka-cluster:Connect')
       expect(payload).toHaveProperty('x-amz-algorithm', 'AWS4-HMAC-SHA256')
       expect(payload).toHaveProperty('x-amz-credential', `${credentials.accessKeyId}/20210101/${region}/kafka-cluster/aws4_request`)

--- a/src/AuthenticationPayloadCreator.spec.js
+++ b/src/AuthenticationPayloadCreator.spec.js
@@ -35,7 +35,7 @@ describe('AuthenticationPayloadCreator', () => {
 
       expect(payload).toHaveProperty('version', '2020_10_22')
       expect(payload).toHaveProperty('host', brokerHost)
-      expect(payload).toHaveProperty('user-agent', 'MSK_IAM_v1.0.0')
+      expect(payload).toHaveProperty('user-agent', 'test-api')
       expect(payload).toHaveProperty('action', 'kafka-cluster:Connect')
       expect(payload).toHaveProperty('x-amz-algorithm', 'AWS4-HMAC-SHA256')
       expect(payload).toHaveProperty('x-amz-credential', `${credentials.accessKeyId}/20210101/${region}/kafka-cluster/aws4_request`)


### PR DESCRIPTION
Hi @jmaver-plume, we try to use this library within a Node.js application currently and encountered that the `getDefaultRoleAssumerWithWebIdentity` function isn't called within the `constructor` of the `AuthenticationPayloadCreator` class. And thanks for this lib!
