### PR TITLE
Passing Region to getDefaultRoleAssumerWithWebIdentity

### DIFF
--- a/src/AuthenticationPayloadCreator.js
+++ b/src/AuthenticationPayloadCreator.js
@@ -16,7 +16,9 @@ class AuthenticationPayloadCreator {
     this.ttl = ttl || '900'
     this.userAgent = userAgent || 'MSK_IAM_v1.0.0'
     this.provider = defaultProvider({
-      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity()
+      roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity({
+        region: process.env.AWS_REGION ?? region
+      })
     })
 
     this.signature = new SignatureV4({


### PR DESCRIPTION
The region is not passed to the AWS SDK which makes it default to us-east-1. This causes a problem in restricted AWS environments since the token can't be generated.