### PR TITLE
Update AWS libraries to pick up a version of fast-xml-parser that addresses CVE-2023-34104.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "@jm18457/kafkajs-msk-iam-authentication-mechanism",
-      "version": "3.0.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "^4.0.0",
-        "@aws-sdk/credential-providers": "^3.282.0",
-        "@aws-sdk/hash-node": "^3.272.0",
-        "@aws-sdk/signature-v4": "^3.282.0"
+        "@aws-sdk/credential-providers": "^3.363.0",
+        "@aws-sdk/hash-node": "^3.357.0",
+        "@aws-sdk/signature-v4": "^3.357.0"
       },
       "devDependencies": {
         "@babel/core": "^7.21.0",
@@ -48,6 +48,21 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
@@ -145,58 +160,47 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.282.0.tgz",
-      "integrity": "sha512-OU9Wy50u31Mog4xmj9o+lLOb/y+yuQBTFwEVYApJtCkPsI2e3DtZFt36IcAy04fcjNUaSD3u6SGgfYo2vDQ2zA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.363.0.tgz",
+      "integrity": "sha512-tsJzgBSCpna85IVsuS7FBIK9wkSl7fs8TJ/QzapIgu8rKss0ySHVO6TeMVAdw2BvaQl7CxU9c3PosjhLWHu6KQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.282.0",
-        "@aws-sdk/config-resolver": "3.282.0",
-        "@aws-sdk/credential-provider-node": "3.282.0",
-        "@aws-sdk/fetch-http-handler": "3.282.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.282.0",
-        "@aws-sdk/middleware-endpoint": "3.282.0",
-        "@aws-sdk/middleware-host-header": "3.282.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.282.0",
-        "@aws-sdk/middleware-retry": "3.282.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.282.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.282.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.282.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.282.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.282.0",
-        "@aws-sdk/util-user-agent-node": "3.282.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sts": "3.363.0",
+        "@aws-sdk/credential-provider-node": "3.363.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-signing": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -218,84 +222,86 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.282.0.tgz",
-      "integrity": "sha512-VzdCCaxlDyU+7wvLDWh+uACQ6RPfaKLQ3yJ2UY0B0SkH4R0E4GLDJ2OJzqS5eyyOsnq1rxfY75S4WYzj8E2cvg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.363.0.tgz",
+      "integrity": "sha512-PZ+HfKSgS4hlMnJzG+Ev8/mgHd/b/ETlJWPSWjC/f2NwVoBQkBnqHjdyEx7QjF6nksJozcVh5Q+kkYLKc/QwBQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.282.0",
-        "@aws-sdk/fetch-http-handler": "3.282.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.282.0",
-        "@aws-sdk/middleware-endpoint": "3.282.0",
-        "@aws-sdk/middleware-host-header": "3.282.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.282.0",
-        "@aws-sdk/middleware-retry": "3.282.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.282.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.282.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.282.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.282.0",
-        "@aws-sdk/util-user-agent-node": "3.282.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.282.0.tgz",
-      "integrity": "sha512-upC4yBZllAXg5OVIuS8Lu9MI1aqfAObl2BBixj9fIYbDanQ02s0b1IwfZqlOqNNkGzMko1AWyiOSyOdVgyJ+xg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.363.0.tgz",
+      "integrity": "sha512-V3Ebiq/zNtDS/O92HUWGBa7MY59RYSsqWd+E0XrXv6VYTA00RlMTbNcseivNgp2UghOgB9a20Nkz6EqAeIN+RQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.282.0",
-        "@aws-sdk/fetch-http-handler": "3.282.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.282.0",
-        "@aws-sdk/middleware-endpoint": "3.282.0",
-        "@aws-sdk/middleware-host-header": "3.282.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.282.0",
-        "@aws-sdk/middleware-retry": "3.282.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.282.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.282.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.282.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.282.0",
-        "@aws-sdk/util-user-agent-node": "3.282.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.2",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.0.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -332,46 +338,47 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.282.0.tgz",
-      "integrity": "sha512-JZybEaST0rloS9drlX/0yJAnKHuV7DlS1n1WZxgaM2DY704ydlGiviiPQvC/q/dItsX4017gscC0blGJcUjK1g==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.363.0.tgz",
+      "integrity": "sha512-0jj14WvBPJQ8xr72cL0mhlmQ90tF0O0wqXwSbtog6PsC8+KDE6Yf+WsxsumyI8E5O8u3eYijBL+KdqG07F/y/w==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.282.0",
-        "@aws-sdk/credential-provider-node": "3.282.0",
-        "@aws-sdk/fetch-http-handler": "3.282.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.282.0",
-        "@aws-sdk/middleware-endpoint": "3.282.0",
-        "@aws-sdk/middleware-host-header": "3.282.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.282.0",
-        "@aws-sdk/middleware-retry": "3.282.0",
-        "@aws-sdk/middleware-sdk-sts": "3.282.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.282.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.282.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.282.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.282.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.282.0",
-        "@aws-sdk/util-user-agent-node": "3.282.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "fast-xml-parser": "4.1.2",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-node": "3.363.0",
+        "@aws-sdk/middleware-host-header": "3.363.0",
+        "@aws-sdk/middleware-logger": "3.363.0",
+        "@aws-sdk/middleware-recursion-detection": "3.363.0",
+        "@aws-sdk/middleware-sdk-sts": "3.363.0",
+        "@aws-sdk/middleware-signing": "3.363.0",
+        "@aws-sdk/middleware-user-agent": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.363.0",
+        "@aws-sdk/util-user-agent-node": "3.363.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.1",
+        "@smithy/middleware-retry": "^1.0.1",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.2",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -392,704 +399,403 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.282.0.tgz",
-      "integrity": "sha512-30qFLh2N4NXQ2EAook7NIFeu1K/nlrRLrdVb2BtGFi/F3cZnz+sy9o0XmL6x+sO9TznWjdNxD1RKQdqoAwGnCQ==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.282.0.tgz",
-      "integrity": "sha512-GsLOt6GzckLQbMzgXOblKcRtXyMu3NcP0vFkYpy4r9oEzoxqPhy1yUpRNLeDv7r2qoa8naN81F5FwPwd17PrKg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.363.0.tgz",
+      "integrity": "sha512-5x42JvqEsBUrm6/qdf0WWe4mlmJjPItxamQhRjuOzeQD/BxsA2W5VS/7n0Ws0e27DNhlnUErcIJd+bBy6j1fqA==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.282.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-cognito-identity": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
-      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.363.0.tgz",
+      "integrity": "sha512-VAQ3zITT2Q0acht0HezouYnMFKZ2vIOa20X4zQA3WI0HfaP4D6ga6KaenbDcb/4VFiqfqiRHfdyXHP0ThcDRMA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
-      "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.282.0.tgz",
-      "integrity": "sha512-2GKduXORcUgOigF1jZF7A1Wh4W/aJt3ynh7xb1vfx020nHx6YDljrEGpzgH6pOVzl7ZhgthpojicCuy2UumkMA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.363.0.tgz",
+      "integrity": "sha512-ZYN+INoqyX5FVC3rqUxB6O8nOWkr0gHRRBm1suoOlmuFJ/WSlW/uUGthRBY5x1AQQnBF8cpdlxZzGHd41lFVNw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.282.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.363.0",
+        "@aws-sdk/credential-provider-process": "3.363.0",
+        "@aws-sdk/credential-provider-sso": "3.363.0",
+        "@aws-sdk/credential-provider-web-identity": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.282.0.tgz",
-      "integrity": "sha512-qyHipZW0ep8STY+SO+Me8ObQ1Ee/aaZTmAK0Os/gB+EsiZhIE+mi6zRcScwdnpgJPLRYMEe4p/Cr6DOrA0G0GQ==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.363.0.tgz",
+      "integrity": "sha512-C1qXFIN2yMxD6pGgug0vR1UhScOki6VqdzuBHzXZAGu7MOjvgHNdscEcb3CpWnITHaPL2ztkiw75T1sZ7oIgQg==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-ini": "3.282.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.282.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.363.0",
+        "@aws-sdk/credential-provider-ini": "3.363.0",
+        "@aws-sdk/credential-provider-process": "3.363.0",
+        "@aws-sdk/credential-provider-sso": "3.363.0",
+        "@aws-sdk/credential-provider-web-identity": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
-      "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.363.0.tgz",
+      "integrity": "sha512-fOKAINU7Rtj2T8pP13GdCt+u0Ml3gYynp8ki+1jMZIQ+Ju/MdDOqZpKMFKicMn3Z1ttUOgqr+grUdus6z8ceBQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.282.0.tgz",
-      "integrity": "sha512-c4nibry7u0hkYRMi7+cWzdwYXfDDG+j3VYFxk2oOvU1VIJRyE6oeJqVaz3jgYLX9brHyrLJjuFCIJCUV/WXgIA==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.363.0.tgz",
+      "integrity": "sha512-5RUZ5oM0lwZSo3EehT0dXggOjgtxFogpT3cZvoLGtIwrPBvm8jOQPXQUlaqCj10ThF1sYltEyukz/ovtDwYGew==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.282.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/token-providers": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.363.0",
+        "@aws-sdk/token-providers": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
-      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.363.0.tgz",
+      "integrity": "sha512-Z6w7fjgy79pAax580wdixbStQw10xfyZ+hOYLcPudoYFKjoNx0NQBejg5SwBzCF/HQL23Ksm9kDfbXDX9fkPhA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.282.0.tgz",
-      "integrity": "sha512-/Pau2Ht15j26ibTSTaJHbx6wA3suNT0Qgu+++6ZUoVCeHL5ZN/otcoebsR/lOZTw8Fji7K5kl8TW41UNAE8s2w==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.363.0.tgz",
+      "integrity": "sha512-hVa1DdYasnLud2EKjDAlDHiV/+H/Zq52chHU00c/R8XwPu1s0kZX3NMmlt0D2HhYqC1mUwtdmE58Jra2POviQQ==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.282.0",
-        "@aws-sdk/client-sso": "3.282.0",
-        "@aws-sdk/client-sts": "3.282.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.282.0",
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-ini": "3.282.0",
-        "@aws-sdk/credential-provider-node": "3.282.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.282.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-cognito-identity": "3.363.0",
+        "@aws-sdk/client-sso": "3.363.0",
+        "@aws-sdk/client-sts": "3.363.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.363.0",
+        "@aws-sdk/credential-provider-env": "3.363.0",
+        "@aws-sdk/credential-provider-ini": "3.363.0",
+        "@aws-sdk/credential-provider-node": "3.363.0",
+        "@aws-sdk/credential-provider-process": "3.363.0",
+        "@aws-sdk/credential-provider-sso": "3.363.0",
+        "@aws-sdk/credential-provider-web-identity": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.282.0.tgz",
-      "integrity": "sha512-RTd53UzKtUucIEdVLGGgtlbVwp0QkOt3ZfHuA/A1lOH7meChSh1kz7B5z3p4HQDpXO+MQ1Y6Ble9Vg2fh1zwJQ==",
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
+      "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
-      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.357.0.tgz",
+      "integrity": "sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
-      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.282.0.tgz",
-      "integrity": "sha512-SDgMLRRTMr9LlHSNk4bXUXynYnkT4oNMqE+FxhjsdbT8hK36eS4AadM58R7nPwgjR3EuWRW4ZRRawLWatpWspA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.282.0.tgz",
-      "integrity": "sha512-8U9Mv/Sbdo1KI6/ip7IIUdBl5pgmalFbfkYAyO+AtmkEvawI9ipdWFs5HB0Dwd1BGVup5choY72Ik/7sCAAFTQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/signature-v4": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.282.0.tgz",
-      "integrity": "sha512-90dfYow4zh4tCatTOnqB3nE/dIAucQLZnMqwN/WBPu0fUqjymzpsNkPchqWBPnSWdNE8w3PiKMqqD9rjYwqw4Q==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.363.0.tgz",
+      "integrity": "sha512-FobpclDCf5Y1ueyJDmb9MqguAdPssNMlnqWQpujhYVABq69KHu73fSCWSauFPUrw7YOpV8kG1uagDF0POSxHzA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
-      "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.363.0.tgz",
+      "integrity": "sha512-SSGgthScYnFGTOw8EzbkvquqweFmvn7uJihkpFekbtBNGC/jGOGO+8ziHjTQ8t/iI/YKubEwv+LMi0f77HKSEg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.282.0.tgz",
-      "integrity": "sha512-cSLq/daEaTEucbP/TgAXIOcpwLu7Bfw3VGzH1U56ngDjI4KWvUheF16JiB6OqKQXduPBPsdZ9dVmkDVKddmCRw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.363.0.tgz",
+      "integrity": "sha512-MWD/57QgI/N7fG8rtzDTUdSqNpYohQfgj9XCFAoVeI/bU4usrkOrew43L4smJG4XrDxlNT8lSJlDtd64tuiUZA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.282.0.tgz",
-      "integrity": "sha512-3+0M1GP9o480IdqHVZbkhTgge63uKhDFlS6cQznpNGj0eIuQPhXRnlEz2/rma0INUqFm6+7qJ5yzHR4WQbfHpw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.282.0.tgz",
-      "integrity": "sha512-Qe20mtJcF6lxt7280FhTFD2IpBDn39MEXmbm/zIkXR2/cAmvji8YhcxhNrq1l7XiuMM6SokBDC/f3dlF1oOC6g==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.363.0.tgz",
+      "integrity": "sha512-1yy2Ac50FO8BrODaw5bPWvVrRhaVLqXTFH6iHB+dJLPUkwtY5zLM3Mp+9Ilm7kME+r7oIB1wuO6ZB1Lf4ZszIw==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.282.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/signature-v4": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
-      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-signing": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.282.0.tgz",
-      "integrity": "sha512-eE5qMDcqqxZPdSwybUEph/knrA2j2cHjW+B2ddROw3Ojg0XLjep5hOhithAudgBREQhYF9pdsBr6mUMynUIrKw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.363.0.tgz",
+      "integrity": "sha512-/7qia715pt9JKYIPDGu22WmdZxD8cfF/5xB+1kmILg7ZtjO0pPuTaCNJ7xiIuFd7Dn7JXp5lop08anX/GOhNRQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/signature-v4": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
-      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/signature-v4": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.282.0.tgz",
-      "integrity": "sha512-P1ealsSrUALo0w0Qu5nBKsNQwsmqIfsoNtFWpaznjIcXE5rRMlZL69zb0KnGbQCBfEXsgaMOWjeGT8I3/XbOHQ==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.363.0.tgz",
+      "integrity": "sha512-ri8YaQvXP6odteVTMfxPqFR26Q0h9ejtqhUDv47P34FaKXedEM4nC6ix6o+5FEYj6l8syGyktftZ5O70NoEhug==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
-      "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.282.0.tgz",
-      "integrity": "sha512-LIA4lsSKA/l1kTR5ERkJG2gARveB7Y40MR6yDwtIuhXeVu7Xo9m4BJFanCYIbyc093W0T53x438bwoBR+R+/fw==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
-      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
-      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
-      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
-      "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.282.0.tgz",
-      "integrity": "sha512-rnSL3UyF/No7+O2EMtN1sTCiqL1a+odbfnfo3wCSl8DH5PEYINt2kZgVEvT1Fgaffk1pUggBBOZoR+arPIIDJA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.357.0.tgz",
+      "integrity": "sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
-      "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-codec": "3.357.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.357.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.282.0.tgz",
-      "integrity": "sha512-Qk/D6i+Hpc0fp/2SRHbfJeKPgUIugzsmye3NL0OV1bqd1Y40dW5LT4u67VcZHwqxzYDKe6Eo+7NHJu7qfvwhog==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.363.0.tgz",
+      "integrity": "sha512-6+0aJ1zugNgsMmhTtW2LBWxOVSaXCUk2q3xyTchSXkNzallYaRiZMRkieW+pKNntnu0g5H1T0zyfCO0tbXwxEA==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.282.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso-oidc": "3.363.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
       "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
-      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
-      "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.282.0.tgz",
-      "integrity": "sha512-D1BlFoA7ZMeK2diDUWFx1xBFrSaJuBZMRBuWbnbT9AnRYNCsASZ8DRU1KkZ8LuFQIwmZz94P9q683emYnZBhiw==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.282.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
-      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
+      "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
-      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.357.0.tgz",
+      "integrity": "sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
-      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.282.0.tgz",
-      "integrity": "sha512-Z639oyTa5fZfyi4Xr64+eiAwBCxfpe9Op4Vhnr1z/RwonQM/qywydv6Ttpeq1q5uQ0nG4wTkOMpfh39g+VqIgw==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.363.0.tgz",
+      "integrity": "sha512-fk9ymBUIYbxiGm99Cn+kAAXmvMCWTf/cHAcB79oCXV4ELXdPa9lN5xQhZRFNxLUeXG4OAMEuCAUUuZEj8Fnc1Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/types": "^1.1.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.282.0.tgz",
-      "integrity": "sha512-GSOdWNmzEd554wR9HBrgeYptKBOybveVwUkd6ws+YTdCOz4xD5Gga+I5JomKkcMEUVdBrJnYVUtq7ZsJy2f11w==",
+      "version": "3.363.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.363.0.tgz",
+      "integrity": "sha512-Fli/dvgGA9hdnQUrYb1//wNSFlK2jAfdJcfNXA6SeBYzSeH5pVGYF4kXF0FCdnMA3Fef+Zn1zAP/hw9v8VJHWQ==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.357.0",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1104,12 +810,12 @@
       }
     },
     "node_modules/@aws-sdk/util-utf8": {
-      "version": "3.254.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
-      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3463,6 +3169,482 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.2.tgz",
+      "integrity": "sha512-tb2h0b+JvMee+eAxTmhnyqyNk51UXIK949HnE14lFeezKsVJTB30maan+CO2IMwnig2wVYQH84B5qk6ylmKCuA==",
+      "dependencies": {
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.2.tgz",
+      "integrity": "sha512-8Bk7CgnVKg1dn5TgnjwPz2ebhxeR7CjGs5yhVYH3S8x0q8yPZZVWwpRIglwXaf5AZBzJlNO1lh+lUhMf2e73zQ==",
+      "dependencies": {
+        "@smithy/types": "^1.1.1",
+        "@smithy/util-config-provider": "^1.0.2",
+        "@smithy/util-middleware": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.2.tgz",
+      "integrity": "sha512-fLjCya+JOu2gPJpCiwSUyoLvT8JdNJmOaTOkKYBZoGf7CzqR6lluSyI+eboZnl/V0xqcfcqBG4tgqCISmWS3/w==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^1.0.2",
+        "@smithy/property-provider": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "@smithy/url-parser": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.2.tgz",
+      "integrity": "sha512-eW/XPiLauR1VAgHKxhVvgvHzLROUgTtqat2lgljztbH8uIYWugv7Nz+SgCavB+hWRazv2iYgqrSy74GvxXq/rg==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^1.1.1",
+        "@smithy/util-hex-encoding": "^1.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.2.tgz",
+      "integrity": "sha512-kynyofLf62LvR8yYphPPdyHb8fWG3LepFinM/vWUTG2Q1pVpmPCM530ppagp3+q2p+7Ox0UvSqldbKqV/d1BpA==",
+      "dependencies": {
+        "@smithy/protocol-http": "^1.1.1",
+        "@smithy/querystring-builder": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "@smithy/util-base64": "^1.0.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.2.tgz",
+      "integrity": "sha512-K6PKhcUNrJXtcesyzhIvNlU7drfIU7u+EMQuGmPw6RQDAg/ufUcfKHz4EcUhFAodUmN+rrejhRG9U6wxjeBOQA==",
+      "dependencies": {
+        "@smithy/types": "^1.1.1",
+        "@smithy/util-buffer-from": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.2.tgz",
+      "integrity": "sha512-B1Y3Tsa6dfC+Vvb+BJMhTHOfFieeYzY9jWQSTR1vMwKkxsymD0OIAnEw8rD/RiDj/4E4RPGFdx9Mdgnyd6Bv5Q==",
+      "dependencies": {
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-pkyBnsBRpe+c/6ASavqIMRBdRtZNJEVJOEzhpxZ9JoAXiZYbkfaSMRA/O1dUxGdJ653GHONunnZ4xMo/LJ7utQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.2.tgz",
+      "integrity": "sha512-pa1/SgGIrSmnEr2c9Apw7CdU4l/HW0fK3+LKFCPDYJrzM0JdYpqjQzgxi31P00eAkL0EFBccpus/p1n2GF9urw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^1.1.1",
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.3.tgz",
+      "integrity": "sha512-GsWvTXMFjSgl617PCE2km//kIjjtvMRrR2GAuRDIS9sHiLwmkS46VWaVYy+XE7ubEsEtzZ5yK2e8TKDR6Qr5Lw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "@smithy/url-parser": "^1.0.2",
+        "@smithy/util-middleware": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.4.tgz",
+      "integrity": "sha512-G7uRXGFL8c3F7APnoIMTtNAHH8vT4F2qVnAWGAZaervjupaUQuRRHYBLYubK0dWzOZz86BtAXKieJ5p+Ni2Xpg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^1.1.1",
+        "@smithy/service-error-classification": "^1.0.3",
+        "@smithy/types": "^1.1.1",
+        "@smithy/util-middleware": "^1.0.2",
+        "@smithy/util-retry": "^1.0.4",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.2.tgz",
+      "integrity": "sha512-T4PcdMZF4xme6koUNfjmSZ1MLi7eoFeYCtodQNQpBNsS77TuJt1A6kt5kP/qxrTvfZHyFlj0AubACoaUqgzPeg==",
+      "dependencies": {
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.2.tgz",
+      "integrity": "sha512-H7/uAQEcmO+eDqweEFMJ5YrIpsBwmrXSP6HIIbtxKJSQpAcMGY7KrR2FZgZBi1FMnSUOh+rQrbOyj5HQmSeUBA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.2.tgz",
+      "integrity": "sha512-HU7afWpTToU0wL6KseGDR2zojeyjECQfr8LpjAIeHCYIW7r360ABFf4EaplaJRMVoC3hD9FeltgI3/NtShOqCg==",
+      "dependencies": {
+        "@smithy/property-provider": "^1.0.2",
+        "@smithy/shared-ini-file-loader": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.3.tgz",
+      "integrity": "sha512-PcPUSzTbIb60VCJCiH0PU0E6bwIekttsIEf5Aoo/M0oTfiqsxHTn0Rcij6QoH6qJy6piGKXzLSegspXg5+Kq6g==",
+      "dependencies": {
+        "@smithy/abort-controller": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.1",
+        "@smithy/querystring-builder": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.2.tgz",
+      "integrity": "sha512-pXDPyzKX8opzt38B205kDgaxda6LHcTfPvTYQZnwP6BAPp1o9puiCPjeUtkKck7Z6IbpXCPUmUQnzkUzWTA42Q==",
+      "dependencies": {
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.1.tgz",
+      "integrity": "sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==",
+      "dependencies": {
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.2.tgz",
+      "integrity": "sha512-6P/xANWrtJhMzTPUR87AbXwSBuz1SDHIfL44TFd/GT3hj6rA+IEv7rftEpPjayUiWRocaNnrCPLvmP31mobOyA==",
+      "dependencies": {
+        "@smithy/types": "^1.1.1",
+        "@smithy/util-uri-escape": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.2.tgz",
+      "integrity": "sha512-IWxwxjn+KHWRRRB+K2Ngl+plTwo2WSgc2w+DvLy0DQZJh9UGOpw40d6q97/63GBlXIt4TEt5NbcFrO30CKlrsA==",
+      "dependencies": {
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.3.tgz",
+      "integrity": "sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.2.tgz",
+      "integrity": "sha512-bdQj95VN+lCXki+P3EsDyrkpeLn8xDYiOISBGnUG/AGPYJXN8dmp4EhRRR7XOoLoSs8anZHR4UcGEOzFv2jwGw==",
+      "dependencies": {
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.2.tgz",
+      "integrity": "sha512-rpKUhmCuPmpV5dloUkOb9w1oBnJatvKQEjIHGmkjRGZnC3437MTdzWej9TxkagcZ8NRRJavYnEUixzxM1amFig==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^1.0.2",
+        "@smithy/is-array-buffer": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "@smithy/util-hex-encoding": "^1.0.2",
+        "@smithy/util-middleware": "^1.0.2",
+        "@smithy/util-uri-escape": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.4.tgz",
+      "integrity": "sha512-gpo0Xl5Nyp9sgymEfpt7oa9P2q/GlM3VmQIdm+FeH0QEdYOQx3OtvwVmBYAMv2FIPWxkMZlsPYRTnEiBTK5TYg==",
+      "dependencies": {
+        "@smithy/middleware-stack": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "@smithy/util-stream": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.1.tgz",
+      "integrity": "sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.2.tgz",
+      "integrity": "sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.2.tgz",
+      "integrity": "sha512-BCm15WILJ3SL93nusoxvJGMVfAMWHZhdeDZPtpAaskozuexd0eF6szdz4kbXaKp38bFCSenA6bkUHqaE3KK0dA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.2.tgz",
+      "integrity": "sha512-Xh8L06H2anF5BHjSYTg8hx+Itcbf4SQZnVMl4PIkCOsKtneMJoGjPRLy17lEzfoh/GOaa0QxgCP6lRMQWzNl4w==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.2.tgz",
+      "integrity": "sha512-nXHbZsUtvZeyfL4Ceds9nmy2Uh2AhWXohG4vWHyjSdmT8cXZlJdmJgnH6SJKDjyUecbu+BpKeVvSrA4cWPSOPA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.2.tgz",
+      "integrity": "sha512-lHAYIyrBO9RANrPvccnPjU03MJnWZ66wWuC5GjWWQVfsmPwU6m00aakZkzHdUT6tGCkGacXSgArP5wgTgA+oCw==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.2.tgz",
+      "integrity": "sha512-HOdmDm+3HUbuYPBABLLHtn8ittuRyy+BSjKOA169H+EMc+IozipvXDydf+gKBRAxUa4dtKQkLraypwppzi+PRw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.2.tgz",
+      "integrity": "sha512-J1u2PO235zxY7dg0+ZqaG96tFg4ehJZ7isGK1pCBEA072qxNPwIpDzUVGnLJkHZvjWEGA8rxIauDtXfB0qxeAg==",
+      "dependencies": {
+        "@smithy/property-provider": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.2.tgz",
+      "integrity": "sha512-9/BN63rlIsFStvI+AvljMh873Xw6bbI6b19b+PVYXyycQ2DDQImWcjnzRlHW7eP65CCUNGQ6otDLNdBQCgMXqg==",
+      "dependencies": {
+        "@smithy/config-resolver": "^1.0.2",
+        "@smithy/credential-provider-imds": "^1.0.2",
+        "@smithy/node-config-provider": "^1.0.2",
+        "@smithy/property-provider": "^1.0.2",
+        "@smithy/types": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.2.tgz",
+      "integrity": "sha512-Bxydb5rMJorMV6AuDDMOxro3BMDdIwtbQKHpwvQFASkmr52BnpDsWlxgpJi8Iq7nk1Bt4E40oE1Isy/7ubHGzg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.2.tgz",
+      "integrity": "sha512-vtXK7GOR2BoseCX8NCGe9SaiZrm9M2lm/RVexFGyPuafTtry9Vyv7hq/vw8ifd/G/pSJ+msByfJVb1642oQHKw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.4.tgz",
+      "integrity": "sha512-RnZPVFvRoqdj2EbroDo3OsnnQU8eQ4AlnZTOGusbYKybH3269CFdrZfZJloe60AQjX7di3J6t/79PjwCLO5Khw==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^1.0.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.2.tgz",
+      "integrity": "sha512-qyN2M9QFMTz4UCHi6GnBfLOGYKxQZD01Ga6nzaXFFC51HP/QmArU72e4kY50Z/EtW8binPxspP2TAsGbwy9l3A==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^1.0.2",
+        "@smithy/node-http-handler": "^1.0.3",
+        "@smithy/types": "^1.1.1",
+        "@smithy/util-base64": "^1.0.2",
+        "@smithy/util-buffer-from": "^1.0.2",
+        "@smithy/util-hex-encoding": "^1.0.2",
+        "@smithy/util-utf8": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.2.tgz",
+      "integrity": "sha512-k8C0BFNS9HpBMHSgUDnWb1JlCQcFG+PPlVBq9keP4Nfwv6a9Q0yAfASWqUCtzjuMj1hXeLhn/5ADP6JxnID1Pg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.2.tgz",
+      "integrity": "sha512-V4cyjKfJlARui0dMBfWJMQAmJzoW77i4N3EjkH/bwnE2Ngbl4tqD2Y0C/xzpzY/J1BdxeCKxAebVFk8aFCaSCw==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^1.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
@@ -5459,18 +5641,24 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastq": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   "private": false,
   "dependencies": {
     "@aws-crypto/sha256-js": "^4.0.0",
-    "@aws-sdk/credential-providers": "^3.282.0",
-    "@aws-sdk/hash-node": "^3.272.0",
-    "@aws-sdk/signature-v4": "^3.282.0"
+    "@aws-sdk/credential-providers": "^3.363.0",
+    "@aws-sdk/hash-node": "^3.357.0",
+    "@aws-sdk/signature-v4": "^3.357.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",


### PR DESCRIPTION
Hi!

We would like to update the versions of the AWS SDK to one that depends on fast-xml-parser 4.2.5 instead of 4.1.2. 4.1.2 is vulnerable to https://www.cve.org/CVERecord?id=CVE-2023-34104, while 4.2.5 is not. 

I ran the simple example against an MSK cluster we have and it authenticated without any issues. If there are any other changes you'd like or steps you want me to follow, just let me know.

Thanks!