### PR TITLE
Fix: Generates different credentials and causes an Access Denied

### DIFF
--- a/src/create-authenticator.ts
+++ b/src/create-authenticator.ts
@@ -5,6 +5,7 @@ import {
   createSaslAuthenticationResponse,
   TYPE,
   Options,
+  executeCredentialsProvider,
 } from ".";
 
 export const createAuthenticator =
@@ -13,8 +14,9 @@ export const createAuthenticator =
     authenticate: async () => {
       const { host, port, logger, saslAuthenticate } = args;
       const broker = `${host}:${port}`;
-      const payloadFactory = new CreatePayload(options);
-
+      const executedOptions = await executeCredentialsProvider(options);
+      const payloadFactory = new CreatePayload(executedOptions);
+      
       try {
         const payload = await payloadFactory.create({ brokerHost: host });
         const authenticateResponse = await saslAuthenticate({

--- a/src/create-mechanism.ts
+++ b/src/create-mechanism.ts
@@ -30,3 +30,12 @@ export const createMechanism = (
   mechanism,
   authenticationProvider: createAuthenticator(options),
 });
+
+export const executeCredentialsProvider = async (
+  executeOptions: Options,
+): Promise<Options> => {
+  let options:Options  = {...executeOptions};
+  options.credentials = typeof executeOptions.credentials === "function"
+    ? await executeOptions.credentials() : executeOptions.credentials;
+    return options;
+};


### PR DESCRIPTION
This PR  adds method to execute credentials provider in the authenticate method, in the flow, the  provider is executed twice,  by CreatePayload and  SignatureV4, this generates differentes credentials and causes an AccesDenied. 

This fix helps to authenticate with a single credentials and with a assume role. 