### PR TITLE
docs: simplify README API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,184 +1,69 @@
 # Kafka MSK IAM integration
 
+KafkaJS custom authentication mechanism for AWS MSK IAM.
+
 ## Installation
 
 Requires `kafkajs` version `2.2.0` or higher.
 
-For more information look at https://kafka.js.org/docs/next/configuration#custom-authentication-mechanisms.
-
 ```shell
-npm i @jm18457/kafkajs-msk-iam-authentication-mechanism 
+npm i @jm18457/kafkajs-msk-iam-authentication-mechanism
 ```
 
-### Setup
+## Usage
 
 ```javascript
-const { Kafka } = require('kafkajs')
+const { Kafka } = require("kafkajs");
 const {
-  createMechanism
-} = require('@jm18457/kafkajs-msk-iam-authentication-mechanism')
+  createMechanism,
+} = require("@jm18457/kafkajs-msk-iam-authentication-mechanism");
 
 const kafka = new Kafka({
-  brokers: ['kafka1:9092', 'kafka2:9092'],
-  clientId: 'my-app',
+  brokers: ["kafka1:9092", "kafka2:9092"],
+  clientId: "my-app",
   ssl: true,
-  sasl: createMechanism({ region: 'eu-central-1' })
-})
+  sasl: createMechanism({ region: "eu-central-1" }),
+});
 ```
 
-You can also use the old way of importing the library.
+You can also pass AWS credentials explicitly. If you do not provide
+credentials, the library uses the AWS SDK default credential provider chain.
 
 ```javascript
-const { Kafka } = require('kafkajs')
-const {
-  Type,
-  awsIamAuthenticator,
-} = require('@jm18457/kafkajs-msk-iam-authentication-mechanism')
-
-
-const provider = awsIamAuthenticator({
-    region: 'eu-central-1'
-})
+const { fromNodeProviderChain } = require("@aws-sdk/credential-providers");
 
 const kafka = new Kafka({
-  brokers: ['kafka1:9092', 'kafka2:9092'],
-  clientId: 'my-app',
+  brokers: ["kafka1:9092", "kafka2:9092"],
+  clientId: "my-app",
   ssl: true,
-  sasl: {
-    mechanism: Type,
-    authenticationProvider: provider
-  }
-})
+  sasl: createMechanism({
+    region: "eu-central-1",
+    credentials: fromNodeProviderChain(),
+  }),
+});
 ```
 
 ## Examples
 
 For working examples look at the `examples` folder.
 
-## API Reference
+## API
 
-### Type Aliases
+### createMechanism(options)
 
-#### Options
+Creates a KafkaJS SASL mechanism object for AWS MSK IAM authentication.
 
-Ƭ **Options**: `Object`
+```javascript
+sasl: createMechanism({
+  region: "eu-central-1",
+});
+```
 
-##### Type declaration
+### Options
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `credentials?` | `AwsCredentialIdentity` \| `Provider`<`AwsCredentialIdentity`\> | **`Default`** fromNodeProviderChain() |
-| `region` | `string` | The AWS region in which the Kafka broker exists. |
-| `ttl?` | `string` | Provides the time period, in seconds, for which the generated presigned URL is valid. **`Default`** 900 |
-| `userAgent?` | `string` | Is a string passed in by the client library to describe the client. **`Default`** MSK_IAM |
-
-##### Defined in
-
-[create-mechanism.ts:5](https://github.com/jmaver-plume/kafkajs-msk-iam-authentication-mechanism/blob/main/src/create-mechanism.ts#L5)
-
-### Variables
-
-#### TYPE
-
-• `Const` **TYPE**: ``"AWS_MSK_IAM"``
-
-##### Defined in
-
-[constants.ts:3](https://github.com/jmaver-plume/kafkajs-msk-iam-authentication-mechanism/blob/main/src/constants.ts#L3)
-
-___
-
-#### Type
-
-• `Const` **Type**: ``"AWS_MSK_IAM"``
-
-##### Defined in
-
-[index.ts:10](https://github.com/jmaver-plume/kafkajs-msk-iam-authentication-mechanism/blob/main/src/index.ts#L10)
-
-### Functions
-
-#### awsIamAuthenticator
-
-▸ **awsIamAuthenticator**(`options`): (`args`: `AuthenticationProviderArgs`) => `Authenticator`
-
-##### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `options` | [`Options`](README.md#options) |
-
-##### Returns
-
-`fn`
-
-▸ (`args`): `Authenticator`
-
-###### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `args` | `AuthenticationProviderArgs` |
-
-###### Returns
-
-`Authenticator`
-
-##### Defined in
-
-[create-authenticator.ts:11](https://github.com/jmaver-plume/kafkajs-msk-iam-authentication-mechanism/blob/main/src/create-authenticator.ts#L11)
-
-___
-
-#### createAuthenticator
-
-▸ **createAuthenticator**(`options`): (`args`: `AuthenticationProviderArgs`) => `Authenticator`
-
-##### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `options` | [`Options`](README.md#options) |
-
-##### Returns
-
-`fn`
-
-▸ (`args`): `Authenticator`
-
-###### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `args` | `AuthenticationProviderArgs` |
-
-###### Returns
-
-`Authenticator`
-
-##### Defined in
-
-[create-authenticator.ts:11](https://github.com/jmaver-plume/kafkajs-msk-iam-authentication-mechanism/blob/main/src/create-authenticator.ts#L11)
-
-___
-
-#### createMechanism
-
-▸ **createMechanism**(`options`, `mechanism?`): `Mechanism`
-
-##### Parameters
-
-| Name | Type | Default value |
-| :------ | :------ | :------ |
-| `options` | [`Options`](README.md#options) | `undefined` |
-| `mechanism` | `string` | `TYPE` |
-
-##### Returns
-
-`Mechanism`
-
-##### Defined in
-
-[create-mechanism.ts:26](https://github.com/jmaver-plume/kafkajs-msk-iam-authentication-mechanism/blob/main/src/create-mechanism.ts#L26)
-
-
+| Option        | Type                                                       | Required | Default                   | Description                                              |
+| ------------- | ---------------------------------------------------------- | -------- | ------------------------- | -------------------------------------------------------- |
+| `region`      | `string`                                                   | Yes      | -                         | AWS region where the MSK cluster exists.                 |
+| `ttl`         | `string`                                                   | No       | `"900"`                   | Presigned authentication payload lifetime in seconds.    |
+| `userAgent`   | `string`                                                   | No       | `"MSK_IAM"`               | User agent value included in the authentication payload. |
+| `credentials` | `AwsCredentialIdentity \| Provider<AwsCredentialIdentity>` | No       | `fromNodeProviderChain()` | AWS credentials or an AWS credentials provider.          |

--- a/examples/simple/package-lock.json
+++ b/examples/simple/package-lock.json
@@ -32,7 +32,7 @@
         "@babel/preset-typescript": "^7.28.5",
         "@eslint/js": "^10.0.1",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.7.0",
+        "@types/node": "^20.19.41",
         "@typescript-eslint/eslint-plugin": "^8.59.3",
         "@typescript-eslint/parser": "^8.59.3",
         "babel-jest": "^30.4.1",
@@ -41,12 +41,13 @@
         "kafkajs": "^2.2.4",
         "mockdate": "^3.0.5",
         "prettier": "^3.8.3",
-        "typedoc": "^0.28.19",
-        "typedoc-plugin-markdown": "^4.11.0",
         "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "kafkajs": ">=2.2.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,6 @@
         "kafkajs": "^2.2.4",
         "mockdate": "^3.0.5",
         "prettier": "^3.8.3",
-        "typedoc": "^0.28.19",
-        "typedoc-plugin-markdown": "^4.11.0",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -2690,20 +2688,6 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
-      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.23.0",
-        "@shikijs/langs": "^3.23.0",
-        "@shikijs/themes": "^3.23.0",
-        "@shikijs/types": "^3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -3255,55 +3239,6 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "node_modules/@shikijs/langs": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@shikijs/themes": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/@shikijs/vscode-textmate": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
@@ -3834,16 +3769,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -3903,13 +3828,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5151,19 +5069,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -6823,16 +6728,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -6862,13 +6757,6 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
-    },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -6908,38 +6796,6 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
-    },
-    "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/markdown-it/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -7361,16 +7217,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8005,43 +7851,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typedoc": {
-      "version": "0.28.19",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
-      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@gerrit0/mini-shiki": "^3.23.0",
-        "lunr": "^2.3.9",
-        "markdown-it": "^14.1.1",
-        "minimatch": "^10.2.5",
-        "yaml": "^2.8.3"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 18",
-        "pnpm": ">= 10"
-      },
-      "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
-      }
-    },
-    "node_modules/typedoc-plugin-markdown": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.11.0.tgz",
-      "integrity": "sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "typedoc": "0.28.x"
-      }
-    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -8055,13 +7864,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -8388,22 +8190,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "kafkajs": "^2.2.4",
     "mockdate": "^3.0.5",
     "prettier": "^3.8.3",
-    "typedoc": "^0.28.19",
-    "typedoc-plugin-markdown": "^4.11.0",
     "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- replace generated TypeDoc README output with concise manual documentation
- document only the recommended createMechanism API
- remove TypeDoc dev dependencies and refresh lockfiles

## Verification
- npm run build
- npm test
- npm run lint
- npx prettier --check README.md package.json